### PR TITLE
Fix build with Clang on Windows and fix compiler warnings

### DIFF
--- a/include/lunatic/cpu.hpp
+++ b/include/lunatic/cpu.hpp
@@ -67,6 +67,8 @@ struct CPU {
     Memory& memory;
   };
 
+  virtual ~CPU() = default;
+
   virtual auto IRQLine() -> bool& = 0;
   virtual void Run(int cycles) = 0;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,3 +70,7 @@ add_library(lunatic STATIC ${SOURCES} ${HEADERS} ${HEADERS_PUBLIC})
 target_include_directories(lunatic PRIVATE .)
 target_include_directories(lunatic PUBLIC ../include)
 target_link_libraries(lunatic PRIVATE fmt xbyak)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_compile_definitions(lunatic PRIVATE NOMINMAX)
+endif()

--- a/src/backend/x86_64/backend.cpp
+++ b/src/backend/x86_64/backend.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 
 #include "backend.hpp"
+#include "common/bit.hpp"
 
 /**
  * TODO:
@@ -1065,16 +1066,16 @@ void X64Backend::CompileMemoryRead(CompileContext const& context, IRMemoryRead* 
 
   if (flags & Word) {
     code.and_(kRegArg1.cvt32(), ~3);
-    code.mov(rax, u64((void*)&X64Backend::ReadWord));
+    code.mov(rax, bit::cast<u64>(&X64Backend::ReadWord));
   }
 
   if (flags & Half) {
     code.and_(kRegArg1.cvt32(), ~1);
-    code.mov(rax, u64((void*)&X64Backend::ReadHalf));
+    code.mov(rax, bit::cast<u64>(&X64Backend::ReadHalf));
   }
 
   if (flags & Byte) {
-    code.mov(rax, u64((void*)&X64Backend::ReadByte));
+    code.mov(rax, bit::cast<u64>(&X64Backend::ReadByte));
   }
 
   code.mov(kRegArg0, u64(this));
@@ -1230,16 +1231,16 @@ void X64Backend::CompileMemoryWrite(CompileContext const& context, IRMemoryWrite
 
   if (flags & Word) {
     code.and_(kRegArg1.cvt32(), ~3);
-    code.mov(rax, u64((void*)&X64Backend::WriteWord));
+    code.mov(rax, bit::cast<u64>(&X64Backend::WriteWord));
   }
 
   if (flags & Half) {
     code.and_(kRegArg1.cvt32(), ~1);
-    code.mov(rax, u64((void*)&X64Backend::WriteHalf));
+    code.mov(rax, bit::cast<u64>(&X64Backend::WriteHalf));
   }
 
   if (flags & Byte) {
-    code.mov(rax, u64((void*)&X64Backend::WriteByte));
+    code.mov(rax, bit::cast<u64>(&X64Backend::WriteByte));
   }
 
   code.mov(kRegArg0, u64(this));

--- a/src/common/bit.hpp
+++ b/src/common/bit.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <climits>
+#include <memory>
+#include <type_traits>
 #include <lunatic/integer.hpp>
 
 namespace bit {
@@ -68,6 +70,18 @@ constexpr auto build_pattern_value(const char* pattern) -> T {
 template<typename T>
 constexpr auto match_pattern(T value, const char* pattern) -> bool {
   return (value & detail::build_pattern_mask<T>(pattern)) == detail::build_pattern_value<T>(pattern);
+}
+
+// https://github.com/MerryMage/dynarmic/blob/5f96ca00b109d99c2ea1d4d141b3e3948edefbea/src/dynarmic/common/cast_util.h#L16-L25
+template <class Dest, class Source>
+constexpr inline auto cast(const Source& source) noexcept -> Dest {
+  static_assert(sizeof(Dest) == sizeof(Source), "size of destination and source objects must be equal");
+  static_assert(std::is_trivially_copyable_v<Dest>, "destination type must be trivially copyable.");
+  static_assert(std::is_trivially_copyable_v<Source>, "source type must be trivially copyable");
+
+  std::aligned_storage_t<sizeof(Dest), alignof(Dest)> dest;
+  std::memcpy(&dest, &source, sizeof(dest));
+  return reinterpret_cast<Dest&>(dest);
 }
 
 } // namespace bit

--- a/src/frontend/ir/emitter.cpp
+++ b/src/frontend/ir/emitter.cpp
@@ -116,6 +116,7 @@ void IREmitter::Optimize() {
           }
           break;
         }
+        default: break;
       }
 
       ++it;
@@ -157,6 +158,7 @@ void IREmitter::Optimize() {
           }
           break;
         }
+        default: break;
       }
 
       ++it;

--- a/src/frontend/ir/emitter.hpp
+++ b/src/frontend/ir/emitter.hpp
@@ -21,6 +21,20 @@ struct IREmitter {
   using InstructionList = std::list<std::unique_ptr<IROpcode>>;
   using VariableList = std::vector<std::unique_ptr<IRVariable>>;
 
+  IREmitter() = default;
+  IREmitter(const IREmitter&) = delete;
+  IREmitter& operator=(const IREmitter&) = delete;
+
+  IREmitter(IREmitter&& emitter) {
+    operator=(std::move(emitter));
+  }
+
+  IREmitter& operator=(IREmitter&& emitter) {
+    std::swap(code, emitter.code);
+    std::swap(variables, emitter.variables);
+    return *this;
+  }
+
   auto Code() const -> InstructionList const& { return code; }
   auto Vars() const -> VariableList const& { return variables; }
   auto ToString() const -> std::string;

--- a/src/frontend/translator/handle/exception.cpp
+++ b/src/frontend/translator/handle/exception.cpp
@@ -13,7 +13,7 @@ namespace frontend {
 auto Translator::Handle(ARMException const& opcode) -> Status {
   Mode new_mode;
   auto exception = opcode.exception;
-  auto branch_address = static_cast<u32>(exception) + 2 * sizeof(u32);
+  u32 branch_address = static_cast<u32>(exception) + 2 * sizeof(u32);
 
   switch (exception) {
     case Exception::Supervisor:

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -63,7 +63,7 @@ struct JIT final : CPU {
   }
 
   auto GetGPR(GPR reg) const -> u32 override {
-    return GetGPR(reg);
+    return const_cast<JIT*>(this)->GetGPR(reg);
   }
 
   auto GetGPR(GPR reg, Mode mode) -> u32& override {
@@ -71,23 +71,23 @@ struct JIT final : CPU {
   }
 
   auto GetGPR(GPR reg, Mode mode) const -> u32 override {
-    return GetGPR(reg, mode);
+    return const_cast<JIT*>(this)->GetGPR(reg, mode);
   }
 
-  auto GetCPSR() -> StatusRegister& {
+  auto GetCPSR() -> StatusRegister& override {
     return state.GetCPSR();
   }
 
-  auto GetCPSR() const -> StatusRegister {
-    return GetCPSR();
+  auto GetCPSR() const -> StatusRegister override {
+    return const_cast<JIT*>(this)->GetCPSR();
   }
 
-  auto GetSPSR(Mode mode) -> StatusRegister& {
+  auto GetSPSR(Mode mode) -> StatusRegister& override {
     return *state.GetPointerToSPSR(mode);
   }
 
-  auto GetSPSR(Mode mode) const -> StatusRegister {
-    return GetSPSR(mode);
+  auto GetSPSR(Mode mode) const -> StatusRegister override {
+    return const_cast<JIT*>(this)->GetSPSR(mode);
   }
 
 private:


### PR DESCRIPTION
These changes allow the library to successfully build on Windows with VS2019's clang compiler. I also fixed some compiler warnings along the way.