### PR TITLE
Don't include the test project when lunatic is included as a subproject in another CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.2)
+
+# Determine whether this is a standalone project or included by other projects
+if(DEFINED PROJECT_NAME)
+  set(IS_SUBPROJECT ON)
+else()
+  set(IS_SUBPROJECT OFF)
+endif()
+
 project(lunatic-root)
 
 add_subdirectory(external)
 add_subdirectory(src)
-add_subdirectory(test)
+if(NOT IS_SUBPROJECT)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
What the title says.