### PR TITLE
Implement Windows-specific aligned_alloc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADERS
   backend/x86_64/register_allocator.hpp
   backend/backend.hpp
   common/bit.hpp
+  common/aligned_memory.hpp
   common/meta.hpp
   common/optional.hpp
   frontend/decode/definition/block_data_transfer.hpp

--- a/src/backend/x86_64/backend.cpp
+++ b/src/backend/x86_64/backend.cpp
@@ -6,10 +6,12 @@
  */
 
 #include <algorithm>
+#include <cstdlib>
 #include <list>
 #include <stdexcept>
 
 #include "backend.hpp"
+#include "common/aligned_memory.hpp"
 #include "common/bit.hpp"
 
 /**
@@ -108,11 +110,11 @@ X64Backend::X64Backend(
 
 X64Backend::~X64Backend() {
   delete code;
-  std::free(buffer);
+  memory::free(buffer);
 }
 
 void X64Backend::CreateCodeGenerator() {
-  buffer = reinterpret_cast<u8*>(std::aligned_alloc(4096, kCodeBufferSize));
+  buffer = reinterpret_cast<u8*>(memory::aligned_alloc(4096, kCodeBufferSize));
 
   if (buffer == nullptr) {
     throw std::runtime_error(

--- a/src/common/aligned_memory.hpp
+++ b/src/common/aligned_memory.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 fleroviux. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#pragma once
+
+#include <cstdlib>
+
+namespace memory {
+
+#ifdef _WIN32
+  void* aligned_alloc(std::size_t alignment, std::size_t size) {
+    return _aligned_malloc(size, alignment);
+  }
+  
+  void free(void* ptr) {
+    _aligned_free(ptr);
+  }
+#else
+  void* aligned_alloc(std::size_t alignment, std::size_t size) {
+    return std::aligned_alloc(alignment, size);
+  }
+  
+  void free(void* ptr) {
+    std::free(ptr);
+  }
+#endif
+
+} // namespace memory


### PR DESCRIPTION
Windows does not implement `std::aligned_alloc` because the requirements for `std::free` are incompatible with the way the Windows kernel does aligned memory allocations.

I've implemented `memory::aligned_alloc` that uses `_aligned_malloc` on Windows or `std::aligned_alloc` on other systems. The counterpart is `memory::aligned_free`, which uses `_aligned_free` or `std::free`.