### PR TITLE
Allow IRQ wait to be cancelled

### DIFF
--- a/include/lunatic/cpu.hpp
+++ b/include/lunatic/cpu.hpp
@@ -75,6 +75,7 @@ struct CPU {
   virtual void Reset() = 0;
   virtual auto IRQLine() -> bool& = 0;
   virtual void WaitForIRQ() = 0;
+  virtual void CancelIRQWait() = 0;
   virtual auto IsWaitingForIRQ() -> bool = 0;
   virtual void ClearICache() = 0;
   virtual void ClearICacheRange(u32 address_lo, u32 address_hi) = 0;

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -37,6 +37,10 @@ struct JIT final : CPU {
     wait_for_irq = true;
   }
 
+  void CancelIRQWait() override {
+    wait_for_irq = false;
+  }
+
   auto IsWaitingForIRQ() -> bool override {
     return wait_for_irq;
   }


### PR DESCRIPTION
This adds the `CancelIRQWait()` function counterpart to `WaitForIRQ()` that clears the `wait_for_irq` flag which is necessary for save state support. Alternatively, we could expose the flag as a reference on `WaitForIRQ()` and let the user set the value accordingly, but that would break existing code.