### PR TITLE
Naïve cycle counting

### DIFF
--- a/include/lunatic/cpu.hpp
+++ b/include/lunatic/cpu.hpp
@@ -78,7 +78,7 @@ struct CPU {
   virtual auto IsWaitingForIRQ() -> bool = 0;
   virtual void ClearICache() = 0;
   virtual void ClearICacheRange(u32 address_lo, u32 address_hi) = 0;
-  virtual void Run(int cycles) = 0;
+  virtual int Run(int cycles) = 0;
 
   virtual auto GetGPR(GPR reg) const -> u32 = 0;
   virtual auto GetGPR(GPR reg, Mode mode) const -> u32 = 0;


### PR DESCRIPTION
This makes `CPU::Run()` return the number of "cycles" (that is, instructions) executed so that user applications that count cycles externally can do their cycle counting. A return value of 0 means that the CPU is halted/waiting for an IRQ. This should not have any impact on existing code.