### PR TITLE
Honor exception_base when resetting JIT state

### DIFF
--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -33,6 +33,7 @@ struct JIT final : CPU {
     wait_for_irq = false;
     cycles_to_run = 0;
     state.Reset();
+    SetGPR(GPR::PC, exception_base);
     block_cache.Flush();
   }
 


### PR DESCRIPTION
Fixes emulators that don't explicitly set R15 on reset.