### PR TITLE
Cast enum value to its underlying type for {fmt}

### DIFF
--- a/src/backend/x86_64/backend.cpp
+++ b/src/backend/x86_64/backend.cpp
@@ -49,7 +49,7 @@ static void ReportBasicBlock(BasicBlock& basic_block, const u8* codeEnd) {
       case Mode::Abort: return "ABT";
       case Mode::Undefined: return "UND";
       case Mode::System: return "SYS";
-      default: return fmt::format("{:02X}", key.Mode());
+      default: return fmt::format("{:02X}", static_cast<uint>(key.Mode()));
       }
     }();
 


### PR DESCRIPTION
Later versions of {fmt} are more strict with parameters and require an implementation of the formatter for custom types including enum classes/structs. This is the only instance in lunatic where {fmt} complains about unformattable parameters.