### PR TITLE
Improve architecture support

### DIFF
--- a/CMakeModules/DetectArchitecture.cmake
+++ b/CMakeModules/DetectArchitecture.cmake
@@ -1,0 +1,33 @@
+include(CheckSymbolExists)
+
+# Universal Binary support for MacOS
+if (CMAKE_OSX_ARCHITECTURES)
+  set(ARCHITECTURE "${CMAKE_OSX_ARCHITECTURES}")
+  return()
+endif()
+
+# Test for architecture and add it to the ARCHITECTURE list 
+function(test_architecture arch_name arch)
+  if (NOT DEFINED ARCHITECTURE)
+    set(CMAKE_REQUIRED_QUIET YES)
+    check_symbol_exists("${arch_name}" "" DETECT_ARCHITECTURE_${arch})
+    unset(CMAKE_REQUIRED_QUIET)
+
+    if (DETECT_ARCHITECTURE_${arch})
+      set(ARCHITECTURE "${arch}" PARENT_SCOPE)
+    endif()
+
+    unset(DETECT_ARCHITECTURE_${arch} CACHE)
+  endif()
+endfunction()
+
+test_architecture("__aarch64__" arm64)
+test_architecture("__ARM64__" arm64)
+test_architecture("_M_ARM64" arm64)
+
+test_architecture("__amd64" x86_64)
+test_architecture("__x86_64__" x86_64)
+test_architecture("__x86_64" x86_64)
+test_architecture("_M_X64" x86_64)
+
+test_architecture("__riscv" riscv)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 project(lunatic CXX)
 
@@ -7,7 +7,13 @@ include(../CMakeModules/FindVTune.cmake)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+# Arch detection
+include(../CMakeModules/DetectArchitecture.cmake)
+if (NOT DEFINED ARCHITECTURE)
+  message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+if ("x86_64" IN_LIST ARCHITECTURE)
   set(ARCH_SPECIFIC_SOURCES
     backend/x86_64/backend.cpp
     backend/x86_64/compile_alu.cpp
@@ -28,7 +34,7 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
     backend/x86_64/vtune.hpp
   )
 else()
-  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  message(FATAL_ERROR "Unsupported architecture(s): ${ARCHITECTURE}")
 endif()
 
 set(SOURCES
@@ -118,7 +124,7 @@ target_include_directories(lunatic PUBLIC
     $<INSTALL_INTERFACE:include>)
 target_link_libraries(lunatic PRIVATE fmt)
 
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+if ("x86_64" IN_LIST ARCHITECTURE)
   target_link_libraries(lunatic PRIVATE xbyak dynarmic)
 
   if (LUNATIC_INCLUDE_XBYAK_FROM_DIRECTORY)


### PR DESCRIPTION
Improve the mechanism used to detect the target architecture. This bumps the cmake version up to `3.3` from `3.2` to utilize `IN_LIST`.